### PR TITLE
Add start/end/topic to stats output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 .DS_Store
-config.json.test
-config.json.qa
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .DS_Store
-
+config.json.test
+config.json.qa

--- a/bot.js
+++ b/bot.js
@@ -49,6 +49,10 @@ function resetData() {
     firebotBugs:[],
     usersTalked: {},
     hourUTC: {},
+    start: startTime,
+    end: endTime,
+    etherpad: etherpad,
+    topic: topic,
   };
 }
 
@@ -247,8 +251,6 @@ client.addListener('error', function(message) {
 var Stats = function() {};
 
 Stats.prototype.generateStats = function(metrcs, from) {
-  metrcs.testday = etherpad;
-
   var keys = Object.keys(metrcs);
   var what = Object.prototype.toString;
   for (var i = 0; i < keys.length; i++) {

--- a/bot.js
+++ b/bot.js
@@ -49,8 +49,8 @@ function resetData() {
     firebotBugs:[],
     usersTalked: {},
     hourUTC: {},
-    start: startTime,
-    end: endTime,
+    start: startTime.toUTCString(),
+    end: endTime.toUTCString(),
     etherpad: etherpad,
     topic: topic,
   };


### PR DESCRIPTION
hi @whimboo !

This patch adds start, end, etherpad, and topic properties to metrics object when we reset data for a new test day, so that they'll be available to generateStats and saved with metrics, until the next test day begins, addressing my comment in issue #23.