### PR TITLE
Report stats using fewer messages (#68)

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -442,23 +442,25 @@ Stats.prototype.generateStats = function(metrcs, from) {
 
   for (var i = 0; i < keys.length; i++) {
     if (what.call(metrcs[keys[i]]).search('Array') > 0) {
-      report = report + "\n" + keys[i] + ":  " + metrcs[keys[i]].join(", ");
+      report = report + keys[i] + ":  " + metrcs[keys[i]].join(", ") + "\n";
     } else {
       if (keys[i] == "activeUsers") {
         var speakers = Object.keys(metrcs.activeUsers);
         var speakersTotal = speakers.length;
-        report = report + "\nThe following " + speakersTotal + " people were active in the channel:  ";
+        report = report + "The following " + speakersTotal + " people were active in the channel:  ";
         for (var t = 0; t < speakersTotal; t++) {
           report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + "  *  ";
         }
+        report = report + "\n";
       } else if (keys[i] == "hourUTC") {
-        report = report + "\nThe following hours (UTC) were active in the channel:  ";
+        report = report + "The following hours (UTC) were active in the channel:  ";
         var speakers = Object.keys(metrcs.hourUTC);
         for (var t = 0; t < speakers.length; t++) {
           report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + "  *  ";
         }
+        report = report + "\n";
       } else {
-        report = report + "\n" + keys[i] + ": " + metrcs[keys[i]];
+        report = report + keys[i] + ": " + metrcs[keys[i]] + "\n";
       }
     }
   }

--- a/bot.js
+++ b/bot.js
@@ -438,28 +438,31 @@ var Stats = function() {};
 Stats.prototype.generateStats = function(metrcs, from) {
   var keys = Object.keys(metrcs);
   var what = Object.prototype.toString;
+  var report ="";
+
   for (var i = 0; i < keys.length; i++) {
     if (what.call(metrcs[keys[i]]).search('Array') > 0) {
-      client.say(from, keys[i] + ":  " + metrcs[keys[i]].join(", "));
+      report = report + "\n" + keys[i] + ":  " + metrcs[keys[i]].join(", ");
     } else {
       if (keys[i] == "activeUsers") {
         var speakers = Object.keys(metrcs.activeUsers);
         var speakersTotal = speakers.length;
-        client.say(from, "The following " + speakersTotal + " people were active in the channel: ");
+        report = report + "\nThe following " + speakersTotal + " people were active in the channel: \n";
         for (var t = 0; t < speakersTotal; t++) {
-          client.say(from, speakers[t] + ": " + metrcs.activeUsers[speakers[t]]);
+          report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + "  *  ";
         }
       } else if (keys[i] == "hourUTC") {
-        client.say(from, "The following hours (UTC) were active in the channel: ");
+        report = report + "\nThe following hours (UTC) were active in the channel: \n";
         var speakers = Object.keys(metrcs.hourUTC);
         for (var t = 0; t < speakers.length; t++) {
-          client.say(from, speakers[t] + ": " + metrcs.hourUTC[speakers[t]]);
+          report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + "  *  ";
         }
       } else {
-        client.say(from, keys[i] + ": " + metrcs[keys[i]]);
+        report = report + "\n" + keys[i] + ": " + metrcs[keys[i]];
       }
     }
   }
+  client.say(from, report);
 };
 
 function restoreTestDayData() {

--- a/bot.js
+++ b/bot.js
@@ -448,19 +448,22 @@ Stats.prototype.generateStats = function(metrcs, from) {
         var speakers = Object.keys(metrcs.activeUsers);
         var speakersTotal = speakers.length;
         report = report + "The following " + speakersTotal + " people were active in the channel:  ";
-        for (var t = 0; t < speakersTotal; t++) {
-          report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + "  *  ";
+        for (var t = 0; t < speakersTotal-1; t++) {
+          report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + ", ";
         }
-        report = report + "\n";
+        report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + "\n";
       } else if (keys[i] == "hourUTC") {
         report = report + "The following hours (UTC) were active in the channel:  ";
         var speakers = Object.keys(metrcs.hourUTC);
-        for (var t = 0; t < speakers.length; t++) {
-          report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + "  *  ";
+        for (var t = 0; t < speakers.length-1; t++) {
+          report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + ", ";
         }
-        report = report + "\n";
+        report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + "\n";
       } else {
-        report = report + keys[i] + ": " + metrcs[keys[i]] + "\n";
+        // report most metrics' string properties only when testday is not active
+        if ((!testDay.active) || (testDay.active && keys[i] === "optOutTotal")) {
+          report = report + keys[i] + ": " + metrcs[keys[i]] + "\n";
+        }
       }
     }
   }

--- a/bot.js
+++ b/bot.js
@@ -447,12 +447,12 @@ Stats.prototype.generateStats = function(metrcs, from) {
       if (keys[i] == "activeUsers") {
         var speakers = Object.keys(metrcs.activeUsers);
         var speakersTotal = speakers.length;
-        report = report + "\nThe following " + speakersTotal + " people were active in the channel: \n";
+        report = report + "\nThe following " + speakersTotal + " people were active in the channel:  ";
         for (var t = 0; t < speakersTotal; t++) {
           report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + "  *  ";
         }
       } else if (keys[i] == "hourUTC") {
-        report = report + "\nThe following hours (UTC) were active in the channel: \n";
+        report = report + "\nThe following hours (UTC) were active in the channel:  ";
         var speakers = Object.keys(metrcs.hourUTC);
         for (var t = 0; t < speakers.length; t++) {
           report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + "  *  ";

--- a/bot.js
+++ b/bot.js
@@ -33,10 +33,10 @@ var ircServer = config.server,
       etherpad: "",
       start: new Date(2000),
       end: new Date(2000),
-      optOutTotal: 0,
-      firebotBugs: [],
       activeUsers: {},
-      hourUTC: {}
+      hourUTC: {},
+      firebotBugs: [],
+      optOutTotal: 0
     },
     help = { ":help" : "This is Help! :)",
              ":bug"  : "Learn how to report a bug",
@@ -67,10 +67,10 @@ function resetData() {
     etherpad: testDay.etherpad,
     start: new Date(testDay.start),
     end: new Date(testDay.end),
-    optOutTotal: 0,
-    firebotBugs:[],
     activeUsers: {},
-    hourUTC: {}
+    hourUTC: {},
+    firebotBugs:[],
+    optOutTotal: 0
   };
 
   saveData("metrics", JSON.stringify(metrics));

--- a/bot.js
+++ b/bot.js
@@ -439,6 +439,7 @@ Stats.prototype.generateStats = function(metrcs, from) {
   var keys = Object.keys(metrcs);
   var what = Object.prototype.toString;
   var report ="";
+  var t = 0;
 
   for (var i = 0; i < keys.length; i++) {
     if (what.call(metrcs[keys[i]]).search('Array') > 0) {
@@ -448,22 +449,20 @@ Stats.prototype.generateStats = function(metrcs, from) {
         var speakers = Object.keys(metrcs.activeUsers);
         var speakersTotal = speakers.length;
         report = report + "The following " + speakersTotal + " people were active in the channel:  ";
-        for (var t = 0; t < speakersTotal-1; t++) {
-          report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + ", ";
+        for (t = 0; t < speakersTotal; t++) {
+          var sep = (t === speakersTotal - 1) ? "\n" : ", ";
+          report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + sep;
         }
-        report = report + speakers[t] + ": " + metrcs.activeUsers[speakers[t]] + "\n";
       } else if (keys[i] == "hourUTC") {
         report = report + "The following hours (UTC) were active in the channel:  ";
-        var speakers = Object.keys(metrcs.hourUTC);
-        for (var t = 0; t < speakers.length-1; t++) {
-          report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + ", ";
+        speakers = Object.keys(metrcs.hourUTC);
+        speakersTotal = speakers.length;
+        for (t = 0; t < speakersTotal; t++) {
+          sep = (t === speakersTotal - 1) ? "\n" : ", ";
+          report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + sep;
         }
-        report = report + speakers[t] + ": " + metrcs.hourUTC[speakers[t]] + "\n";
       } else {
-        // report most metrics' string properties only when testday is not active
-        if ((!testDay.active) || (testDay.active && keys[i] === "optOutTotal")) {
-          report = report + keys[i] + ": " + metrcs[keys[i]] + "\n";
-        }
+        report = report + keys[i] + ": " + metrcs[keys[i]] + "\n";
       }
     }
   }


### PR DESCRIPTION
Hi, @whimboo!

Here’s a quick but incomplete fix for issue #68, accumulating active users stats and active hours stats each on a single line. This produces a readable stats report using 8 messages plus whatever additional messages node-irc splits off for >512 character lines of active users and active hours.

node-irc splits message not only at 512 characters but also at \n. It's challenging to produce a readable report using the minimum number of messages without using \n.

Maybe this is good enough?